### PR TITLE
Correct treatment of period (.) and forward slash (/)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.0.1] - 2019-11-29
+### Added
+- Added CHANGELOG.md
+### Fixed
+- Fixed error where period (.) and forward slash (/) were wrongly stripped, instead of encoded as dashes (-)
+
 ## [1.0.0] - 2017-09-07
 ### Added
 - Initial Release

--- a/assets/wp-fe-sanitize-title.js
+++ b/assets/wp-fe-sanitize-title.js
@@ -19,6 +19,8 @@ function wpFeSanitizeTitle( title ) {
 				// Strip any HTML tags.
 				title.replace( /<[^>]+>/ig, '' )
 			).toLowerCase()
+			// Replace any forward slashes (/) or periods (.) with a dash (-).
+			.replace(/[\/\.]/g, '-')
 			// Replace anything that is not a:
 				// word character
 				// space

--- a/fe-sanitize-title-js.php
+++ b/fe-sanitize-title-js.php
@@ -36,6 +36,7 @@ function fe_sanitize_title_js_shortcode() {
 		'523 abc GHI!*&m5^&3#e@$/',
 		'Captain <strong>Awesome</strong>',
 		'Spaces, -Dashes-, and other ch@racter$ are %REMOVED%!',
+		'M.Brown/Beige',
 	);
 	$test_data = array();
 	foreach ( $test_strs as $test_str ) {

--- a/fe-sanitize-title-js.php
+++ b/fe-sanitize-title-js.php
@@ -3,7 +3,7 @@
  * Plugin Name: Sanitize Title JavaScript Shortcode
  * Plugin URI: https://github.com/salcode/fe-sanitize-title-js
  * Description: Use the shortcode [sanitize-title-js] to display a code block that shows how to recreate the WordPress PHP function sanitize_title() in JavaScript.
- * Version: 1.0.0
+ * Version: 1.0.1
  * Author: Sal Ferrarello
  * GitHub Plugin URI: https://github.com/salcode/fe-sanitize-title-js
  * Author URI: http://salferrarello.com/


### PR DESCRIPTION
Previous behavior was to remove these characters (which was wrong), the corrected behavior is to replace them with a dash.

## Wrong Behavior

![Screen Shot 2019-11-29 at 13 49 58 ](https://user-images.githubusercontent.com/5194588/69886279-28203e80-12af-11ea-8fd4-f880678d8cc8.png)


## Corrected Behavior

![Screen Shot 2019-11-29 at 13 49 15 ](https://user-images.githubusercontent.com/5194588/69886262-15a60500-12af-11ea-9764-8fe355313d86.png)
