### PR TITLE
Encode en dash and em dash to keyboard dash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed issue with en dashes and em dashes not being properly encoded. See #8
 
 ## [1.0.1] - 2019-11-29
 ### Added

--- a/assets/wp-fe-sanitize-title.js
+++ b/assets/wp-fe-sanitize-title.js
@@ -79,6 +79,7 @@ function wpFeSanitizeTitle( title ) {
 			return diacriticsMap;
 		}
 		var defaultDiacriticsRemovalMap = [
+			{'base':'-', 'letters':'\u2013\u2014'},
 			{'base':'A', 'letters':'\u0041\u24B6\uFF21\u00C0\u00C1\u00C2\u1EA6\u1EA4\u1EAA\u1EA8\u00C3\u0100\u0102\u1EB0\u1EAE\u1EB4\u1EB2\u0226\u01E0\u00C4\u01DE\u1EA2\u00C5\u01FA\u01CD\u0200\u0202\u1EA0\u1EAC\u1EB6\u1E00\u0104\u023A\u2C6F'},
 			{'base':'AA','letters':'\uA732'},
 			{'base':'AE','letters':'\u00C6\u01FC\u01E2'},

--- a/fe-sanitize-title-js.php
+++ b/fe-sanitize-title-js.php
@@ -37,6 +37,8 @@ function fe_sanitize_title_js_shortcode() {
 		'Captain <strong>Awesome</strong>',
 		'Spaces, -Dashes-, and other ch@racter$ are %REMOVED%!',
 		'M.Brown/Beige',
+		'This contains an en dash–here',
+		'This contains an em dash—here',
 	);
 	$test_data = array();
 	foreach ( $test_strs as $test_str ) {

--- a/fe-sanitize-title-js.php
+++ b/fe-sanitize-title-js.php
@@ -38,7 +38,11 @@ function fe_sanitize_title_js_shortcode() {
 		'Spaces, -Dashes-, and other ch@racter$ are %REMOVED%!',
 		'M.Brown/Beige',
 		'This contains an en dash–here',
+		'This contains an en dash – here',
+		'This contains an en dash-– here with a keyboard dash',
 		'This contains an em dash—here',
+		'This contains an em dash — here',
+		'This contains an em dash-—-here surrounded by keyboard dashes.',
 	);
 	$test_data = array();
 	foreach ( $test_strs as $test_str ) {


### PR DESCRIPTION
A big thank you to @mattradford for catching this error doing all the legwork to determine the unicode character values.

This PR includes updates to the `[sanitize-title-js]` shortcode to include the strings that were encoding properly and the fix.

See #8 