### PR TITLE
Add code to handle non-breaking space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0.4] - 2020-04-24
+### Fixed
+- Non-breaking spaces are now properly encoded as dashes (-).
+
 ## [1.0.3] - 2020-02-28
 ### Fixed
 - Bumped versions of assets being loaded in order to properly cache bust

--- a/assets/wp-fe-sanitize-title.js
+++ b/assets/wp-fe-sanitize-title.js
@@ -81,7 +81,7 @@ function wpFeSanitizeTitle( title ) {
 			return diacriticsMap;
 		}
 		var defaultDiacriticsRemovalMap = [
-			{'base':'-', 'letters':'\u2013\u2014'},
+			{'base':'-', 'letters':'\u2013\u2014\u00A0'},
 			{'base':'A', 'letters':'\u0041\u24B6\uFF21\u00C0\u00C1\u00C2\u1EA6\u1EA4\u1EAA\u1EA8\u00C3\u0100\u0102\u1EB0\u1EAE\u1EB4\u1EB2\u0226\u01E0\u00C4\u01DE\u1EA2\u00C5\u01FA\u01CD\u0200\u0202\u1EA0\u1EAC\u1EB6\u1E00\u0104\u023A\u2C6F'},
 			{'base':'AA','letters':'\uA732'},
 			{'base':'AE','letters':'\u00C6\u01FC\u01E2'},

--- a/assets/wp-fe-sanitize-title.js
+++ b/assets/wp-fe-sanitize-title.js
@@ -1,7 +1,7 @@
 /**
  * Original Source: https://salferrarello.com/wordpress-sanitize-title-javascript/
  *
- * Version: 1.0.3
+ * Version: 1.0.4
  *
  * JavaScript function to mimic the WordPress PHP function sanitize_title()
  * See https://codex.wordpress.org/Function_Reference/sanitize_title

--- a/fe-sanitize-title-js.php
+++ b/fe-sanitize-title-js.php
@@ -3,7 +3,7 @@
  * Plugin Name: Sanitize Title JavaScript Shortcode
  * Plugin URI: https://github.com/salcode/fe-sanitize-title-js
  * Description: Use the shortcode [sanitize-title-js] to display a code block that shows how to recreate the WordPress PHP function sanitize_title() in JavaScript.
- * Version: 1.0.3
+ * Version: 1.0.4
  * Author: Sal Ferrarello
  * GitHub Plugin URI: https://github.com/salcode/fe-sanitize-title-js
  * Author URI: http://salferrarello.com/
@@ -59,7 +59,7 @@ function fe_sanitize_title_js_shortcode() {
 		'fe-sanitize-title-js',
 		plugins_url( 'assets/wp-fe-sanitize-title.js', __FILE__ ) ,
 		array(),
-		'1.0.3',
+		'1.0.4',
 		true
 	);
 
@@ -68,7 +68,7 @@ function fe_sanitize_title_js_shortcode() {
 		'fe-sanitize-title-demo-js',
 		plugins_url( 'assets/wp-fe-sanitize-title-demo.js', __FILE__ ) ,
 		array( 'fe-sanitize-title-js' ),
-		'1.0.3',
+		'1.0.4',
 		true
 	);
 

--- a/fe-sanitize-title-js.php
+++ b/fe-sanitize-title-js.php
@@ -43,6 +43,7 @@ function fe_sanitize_title_js_shortcode() {
 		'This contains an em dash—here',
 		'This contains an em dash — here',
 		'This contains an em dash-—-here surrounded by keyboard dashes.',
+		'Non-breaking space', // This line contains a non-breaking space.
 	);
 	$test_data = array();
 	foreach ( $test_strs as $test_str ) {


### PR DESCRIPTION
Note: In the example string added here, the non-breaking space was
created in the Vim text editor with the key combination

`Ctrl-v x a 0`

Based on this Stackoverflow answer https://stackoverflow.com/a/31570934

Thanks to @BenRutlandWeb for reporting the problem and providing a solution. 👍 

Fixes #14